### PR TITLE
Add support to Java Stream feature

### DIFF
--- a/src/main/java/remy/task/TaskList.java
+++ b/src/main/java/remy/task/TaskList.java
@@ -45,6 +45,8 @@ public class TaskList {
      * Prints the tasks in the list. If a date is specified, only tasks
      * that are covered by that date are printed.
      *
+     * Apply streams to handle tasks listing, do filtering and mapping on those tasks
+     *
      * @param specifiedDate date to filter tasks by; if null, all tasks are printed
      */
     public List<String> getListing(LocalDate specifiedDate, String keyword) {


### PR DESCRIPTION
Task listing currently uses imperative loops without streams and performs filtering and status extraction with manual iteration.

The iterative approach is verbose, harder to compose for different user-delected indicators, makes it difficult to read and test filtering logic.

Replace manual loops with stream pipeline, filter tasks based on user's command, map each Task to its getStatus() method, collect results while preserving encounter order.

A stream pipeline expresses filtering and mapping declaratively, reduces incidental complexity and keeps predicates localized.